### PR TITLE
nairo: Reduce quick_qs_offset_height

### DIFF
--- a/rro_overlays/FrameworksResOverlayVeux/res/values/dimens.xml
+++ b/rro_overlays/FrameworksResOverlayVeux/res/values/dimens.xml
@@ -23,5 +23,6 @@
     <dimen name="status_bar_height_default">28dp</dimen>
     <dimen name="status_bar_height_landscape">28dp</dimen>
     <dimen name="status_bar_height_portrait">94px</dimen>
+    <dimen name="quick_qs_offset_height">48dp</dimen>
     
 </resources>


### PR DESCRIPTION
This doesn't need to be tied down to status bar height. This way, we have the minimum for tappable items but prevent scrolling on default size portrait with media.
It seems to fix the Quick PullDown lag issue on veux.

Test: manual
Fixes: 189982925
Change-Id: I358696f4140791f84285f97735e1072deb48cdb9
Signed-off-by: Sourav <thefallnn@gmail.com>